### PR TITLE
Add pointer to linear models slides to table of contents again

### DIFF
--- a/jupyter-book/linear_models/linear_models_slides.md
+++ b/jupyter-book/linear_models/linear_models_slides.md
@@ -1,0 +1,13 @@
+# 🎥 Intuitions on linear models
+
+<iframe class="video" width="640px" height="480px"
+        src="https://www.youtube.com/embed/ksEGivkPP7I?rel=0"
+        allowfullscreen></iframe>
+
+<iframe class="slides"
+        src="../slides/index.html?file=../slides/linear_models.md"></iframe>
+
+To navigate in the slides, **first click on the slides**, then:
+- press the **arrow keys** to go to the next/previous slide;
+- press **"P"** to toggle presenter mode to see the notes;
+- press **"F"** to toggle full-screen mode.


### PR DESCRIPTION
Adds a missing section with the embedded YouTube video and slides about linear models.